### PR TITLE
update products table to change status column to active #44

### DIFF
--- a/dev/migrations/20251020_155419_change_product_status.sql
+++ b/dev/migrations/20251020_155419_change_product_status.sql
@@ -1,0 +1,10 @@
+-- Migration: 20251020_155419_change_product_status.sql
+-- Created: 2025-10-20 15:54:19
+-- Description: change-product-status
+START TRANSACTION;
+
+-- write SQL below this line
+ALTER TABLE `products`
+    CHANGE COLUMN `status` `active` ENUM('0','1') NOT NULL DEFAULT '1';
+
+COMMIT;


### PR DESCRIPTION
This pull request introduces a database migration that updates the `products` table. The main change is renaming and altering the `status` column to `active`, and restricting its possible values.

**Database schema changes:**

* In the `products` table, renamed the `status` column to `active` and changed its type to an `ENUM('0','1')` with a default value of `'1'`.